### PR TITLE
Disable joystick warning

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -9,6 +9,7 @@ import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGReader;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 
@@ -33,6 +34,7 @@ public class Robot extends LoggedRobot {
      */
     @Override
     public void robotInit() {
+        DriverStation.silenceJoystickConnectionWarning(true);
 
         // Set up data receivers & replay source
         switch (CONSTANTS.getCurrentOperatingMode()) {


### PR DESCRIPTION
Disable the recurring joystick warnings. Driver/technician is already looking at the joysticks light in the DS UI.